### PR TITLE
Updating importing path for ipython

### DIFF
--- a/showscore/html_renderer.py
+++ b/showscore/html_renderer.py
@@ -86,7 +86,7 @@ def showXML(xml, title=True, tab=False):
 
     if runningInNotebook() == True and tab == False:
         # display the score inline in the notebook
-        from IPython.core.display import HTML, Javascript, display
+        from IPython.display import HTML, Javascript, display
 
         display(HTML(f'<div id="{divId}"></div>'))
         display(Javascript(script))


### PR DESCRIPTION
The current version of the show function shows an error in importing display in python 3.12.9 and ipython 9.2

By changing the import statement the error is fixed.

Tested in VSCode, Jupyter and the Chrome with Python version 3.12.9